### PR TITLE
bugfix: remove requirement to import crate explicitly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,5 @@
 [workspace]
-members = ["toml_const", "toml_const_macros"]
+members = ["toml_const", "toml_const_macros", "toml_const_tests"]
 resolver = "2"
 
 [workspace.package]

--- a/toml_const/src/lib.rs
+++ b/toml_const/src/lib.rs
@@ -22,20 +22,3 @@ impl<T: 'static + Copy> Deref for crate::Array<T> {
         self.0
     }
 }
-
-#[cfg(test)]
-mod tests {
-    use crate as toml_const;
-
-    // example.toml must parse completely
-    macros::toml_const! {
-        pub const TOML_CONST_EXAMPLE: "../example.toml";
-
-        static CARGO_TOML: "Cargo.toml" {
-            "src/toml_const_macros/Cargo.toml";
-            "non_existent.toml";
-        }
-    }
-
-    macros::toml_const_ws! {pub static TOML_CONST_EXAMPLE_WS: "./example.toml"; }
-}

--- a/toml_const_macros/src/custom_struct.rs
+++ b/toml_const_macros/src/custom_struct.rs
@@ -483,8 +483,6 @@ pub fn def_inner_tables(table: &toml::Table, key: &Key<'_>) -> pm2::TokenStream 
         #self_def
 
         pub mod #mod_self {
-            use super::toml_const;
-
             #inner_defs
         }
     }
@@ -500,20 +498,6 @@ mod tests {
     use std::str::FromStr;
 
     use super::*;
-
-    // #[test]
-    // fn test_screaming_snake_case() {
-    //     let input = "hello world";
-    //     let res = input.to_variable_ident();
-    //     assert_eq!(res, "HELLO_WORLD");
-    // }
-
-    // #[test]
-    // fn test_camel_case() {
-    //     let input = "hello world";
-    //     let res = to_camel_case(input);
-    //     assert_eq!(res, "HelloWorld");
-    // }
 
     #[test]
     fn test_sub_tables() {

--- a/toml_const_tests/Cargo.toml
+++ b/toml_const_tests/Cargo.toml
@@ -1,0 +1,8 @@
+[package]
+name = "toml_const_tests"
+edition.workspace = true
+version.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+toml_const = { path = "../toml_const" }

--- a/toml_const_tests/src/lib.rs
+++ b/toml_const_tests/src/lib.rs
@@ -1,0 +1,19 @@
+//! Test library for the toml_const crate.
+#![cfg(test)]
+
+toml_const::toml_const! {
+    pub const TOML_CONST_EXAMPLE: "../example.toml";
+
+    static CARGO_TOML: "Cargo.toml" {
+        use "src/toml_const_macros/Cargo.toml";
+        "non_existent.toml";
+    }
+}
+
+toml_const::toml_const_ws! {pub static TOML_CONST_EXAMPLE_WS: "./example.toml"; }
+
+#[test]
+fn test_ws_crate_macro_equal() {
+    assert_eq!(TOML_CONST_EXAMPLE.AGE, TOML_CONST_EXAMPLE_WS.AGE);
+    assert_eq!(TOML_CONST_EXAMPLE.COLORS.0, TOML_CONST_EXAMPLE_WS.COLORS.0);
+}


### PR DESCRIPTION
- current version requires user to `use toml_const;` explicitly
- shift macro tests to separate crate