### PR TITLE
bugfix: array instantiation

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 # remember to update macro version depended on in toml_const/Cargo.toml
-version = "1.2.0"
+version = "1.2.1"
 rust-version = "1.56"
 
 [workspace.dependencies]

--- a/toml_const/Cargo.toml
+++ b/toml_const/Cargo.toml
@@ -22,5 +22,5 @@ phf = ["dep:phf", "macros/phf"]
 
 [dependencies]
 toml = { workspace = true }
-macros = { path = "../toml_const_macros", package = "toml_const_macros", version = "1.2.0", default-features = false }
+macros = { path = "../toml_const_macros", package = "toml_const_macros", version = "1.2.1", default-features = false }
 phf = { version = "0.12", features = ["macros"], optional = true }

--- a/toml_const_tests/src/lib.rs
+++ b/toml_const_tests/src/lib.rs
@@ -33,5 +33,13 @@ mod tests {
         for item in NORMALIZE_TOML.identical_values.map().into_iter() {
             println!("{}: {:?}", item.0, item.1);
         }
+
+        println!("{:?}", NORMALIZE_TOML.items)
+    }
+
+    #[test]
+    fn test_arrays_preserve_original_len() {
+        assert!(NORMALIZE_TOML.items.len() > 1);
+        assert!(NORMALIZE_TOML.table_map_array.map_array.len() > 1);
     }
 }


### PR DESCRIPTION
- fix case where arrays of len > 1 are instantiated with only one element
- order params correctly during table construction
- add tests