### PR TITLE
feature: replace chars to parse 'cfg(...)' keys

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,7 +5,7 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 # remember to update macro version depended on in toml_const/Cargo.toml
-version = "1.2.1"
+version = "1.2.2-alpha"
 rust-version = "1.56"
 
 [workspace.dependencies]

--- a/toml_const/Cargo.toml
+++ b/toml_const/Cargo.toml
@@ -22,5 +22,5 @@ phf = ["dep:phf", "macros/phf"]
 
 [dependencies]
 toml = { workspace = true }
-macros = { path = "../toml_const_macros", package = "toml_const_macros", version = "1.2.1", default-features = false }
+macros = { path = "../toml_const_macros", package = "toml_const_macros", version = "1.2.2-alpha", default-features = false }
 phf = { version = "0.12", features = ["macros"], optional = true }

--- a/toml_const_macros/src/instantiate.rs
+++ b/toml_const_macros/src/instantiate.rs
@@ -10,7 +10,9 @@ use syn::{punctuated::Punctuated, Ident};
 use crate::TomlValue;
 
 /// Chars to replace when converting to an identifier.
-const REPLACE_CHARS: &[char] = &[' ', '-', '_', ':', '.', '/', '\\', '"'];
+const REPLACE_CHARS: &[char] = &[
+    ' ', '-', '_', ':', '.', '/', '\\', '"', '\'', '(', ')', '=', ',',
+];
 
 /// Generate the instantiation of an item. This can be a custom struct or a simple value.
 /// If a key is provided, the instantiation will be in a field-value pair.
@@ -400,5 +402,23 @@ mod tests {
         });
 
         println!("inter: {inter}");
+    }
+
+    #[test]
+    fn test_cfg_identifiers() {
+        let key = "cfg(any(target_os = \"android\", target_os = \"ios\"))";
+        let var = key.to_variable_ident();
+        let ty = key.to_type_ident();
+        assert_eq!(
+            var.to_string(),
+            "CFG_ANY_TARGET_OS____ANDROID___TARGET_OS____IOS___"
+        );
+        assert_eq!(ty.to_string(), "CfgAnyTargetOsAndroidTargetOsIos");
+
+        let simple_key = "cfg(unix)";
+        let var_simple = simple_key.to_variable_ident();
+        let ty_simple = simple_key.to_type_ident();
+        assert_eq!(var_simple.to_string(), "CFG_UNIX_");
+        assert_eq!(ty_simple.to_string(), "CfgUnix");
     }
 }


### PR DESCRIPTION
Extend `instantiate::REPLACE_CHARS` to parse `'cfg(...)'` keys that are common in `Cargo.toml` files. Fixes #9.