### PR TITLE
Improvement/forwarded attrs

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,9 +5,9 @@ resolver = "2"
 [workspace.package]
 edition = "2021"
 # remember to update macro version depended on in toml_const/Cargo.toml
-version = "1.2.2-alpha"
+version = "1.3.0"
 rust-version = "1.56"
 
 [workspace.dependencies]
-toml = { version = "0.8", features = ["preserve_order"] }
+toml = { version = "0.9", features = ["preserve_order"] }
 indexmap = "2"

--- a/toml_const/Cargo.toml
+++ b/toml_const/Cargo.toml
@@ -22,5 +22,5 @@ phf = ["dep:phf", "macros/phf"]
 
 [dependencies]
 toml = { workspace = true }
-macros = { path = "../toml_const_macros", package = "toml_const_macros", version = "1.2.2-alpha", default-features = false }
-phf = { version = "0.12", features = ["macros"], optional = true }
+macros = { path = "../toml_const_macros", package = "toml_const_macros", version = "1.3.0", default-features = false }
+phf = { version = "0.13", features = ["macros"], optional = true }

--- a/toml_const/README.md
+++ b/toml_const/README.md
@@ -1,7 +1,7 @@
 # toml_const
 
 <div align="center">
-
+`
 **TOML compile-time constants**
 
 <!-- ![crate license](https://img.shields.io/crates/l/toml_const) -->
@@ -156,7 +156,9 @@ The union of all formats will be used to generate the final datetime format.
 
 ## Attributes
 
-Docstrings and derive attributes are supported.
+Derive attributes are automatically forwarded to struct definitions.
+Docstrings are automatically forwarded to its instantiation.
+
 `Clone`, `Copy`, and `Debug` are automatically derived for all types.
 
 ```rust
@@ -172,6 +174,24 @@ toml_const! {
 }
 ```
 
+### Advanced attributes
+
+Not all attributes can be forwarded to the generated code, as there are 2 variants of code generated: struct definitions and the final instantiation.
+Attributes can be forwarded to struct definitions and the struct instantiation by using `#[define(ATTR)]` and `#[instance(ATTR)]` respectively.
+
+Attributes that are not `derive`, `doc`, `define` and `instance` are forwarded to both variants.
+Note that this *may* cause compile issues if the attribute is not valid for either variant.
+
+| Attribute | Forwarded as | Forwarded to |
+| --- | --- | -- |
+| `#[derive(Attribute)]` | `#[derive(Attribute)]` | struct definitions |
+| `#[define(cfg_attr(debug_assertions, Derive(Macro)))]` | `#[cfg_attr(debug_assertions, Derive(Macro))]` | struct definitions |
+| `#[doc = "Docstring"]` | `#[doc = "Docstring"]` | instantiation |
+| `#[define(doc = "Docstring")]` | `#[doc = "Docstring"]` | definition |
+| `#[define(derive(Attribute))]` | `#[derive(Attribute)]` | struct definitions |
+| `#[instance(allow(unused))]` | `#[allow(unused)]` | instantiation |
+| `#[rustfmt::skip]` | `#[rustfmt::skip]` | All definitions and instantiation |
+
 ## Limitations
 
 This library does not support the full TOML specification.
@@ -180,7 +200,7 @@ It **will fail to**:
 
 - generate arrays with distinct types (arrays containing different types, arrays of tables with conflicting key types)
 - create a struct from a table with a blank key `"" = true`
-- parse reserved keys (`__map__` is reserved cannot be used as a key)
+- parse reserved keys (`__map__` is reserved and it cannot be used as a key)
 
 It **will modify**:
 

--- a/toml_const_macros/src/lib.rs
+++ b/toml_const_macros/src/lib.rs
@@ -160,14 +160,13 @@ pub fn toml_const_inner(input: pm::TokenStream) -> pm::TokenStream {
         .as_table()
         .expect("conversion back to table must not fail");
 
-    let derive_attrs = input
-        .attrs
-        .iter()
-        .filter(|attr| attr.path().is_ident("derive"))
-        .cloned()
-        .collect::<Vec<_>>();
+    let definition_attrs = match input.definition_attrs() {
+        Ok(def) => def,
+        Err(e) => return e.to_compile_error().into(),
+    };
 
-    let table_definitions = toml_val_table.definition(&input.item_ident.to_string(), &derive_attrs);
+    let table_definitions =
+        toml_val_table.definition(&input.item_ident.to_string(), &definition_attrs);
 
     let instantiation =
         toml_table.instantiate(&input.item_ident.to_string(), &toml_val_table, vec![]);
@@ -186,16 +185,18 @@ pub fn toml_const_inner(input: pm::TokenStream) -> pm::TokenStream {
     let item_ident = &input.item_ident;
     let item_ty = input.item_ident.to_string().to_type_ident();
 
-    let doc_attrs = input
-        .doc_attrs()
-        .into_iter()
-        .map(|a| a.to_token_stream())
-        .collect::<pm2::TokenStream>();
+    let instance_attrs = match input.instantiation_attrs() {
+        Ok(instance) => instance
+            .into_iter()
+            .map(|a| a.to_token_stream())
+            .collect::<pm2::TokenStream>(),
+        Err(e) => return e.to_compile_error().into(),
+    };
 
     quote! {
         #table_definitions
 
-        #doc_attrs
+        #instance_attrs
         #pub_token #static_const_token #item_ident: #item_ty = #instantiation;
     }
     .into()

--- a/toml_const_macros/src/parse.rs
+++ b/toml_const_macros/src/parse.rs
@@ -6,8 +6,13 @@ use std::path::{Path, PathBuf};
 use proc_macro2 as pm2;
 use proc_macro2::{Delimiter, Group};
 use quote::{quote, ToTokens, TokenStreamExt};
-use syn::Ident;
+use syn::spanned::Spanned;
 use syn::{braced, parse::Parse, punctuated::Punctuated, LitStr};
+use syn::{Ident, Token};
+
+// attributes to forward
+const INSTANTIATION_ATTR_PATH: &str = "instance";
+const DEFINITION_ATTR_PATH: &str = "define";
 
 #[derive(Clone)]
 pub struct MultipleMacroInput(pub Vec<MacroInput>);
@@ -342,14 +347,88 @@ impl MacroInput {
         Ok(merged)
     }
 
-    pub fn doc_attrs(&self) -> Vec<&syn::Attribute> {
+    /// Inner method for [MacroInput::define_attr] and [MacroInput::instance_attr]
+    fn strip_attr_path_and_transform(
+        attr: &syn::Attribute,
+        attr_path: &str,
+    ) -> Result<Option<syn::Attribute>, syn::Error> {
+        match &attr.meta {
+            syn::Meta::Path(path) => Err(syn::Error::new(
+                path.span(),
+                format!("Nothing to forward. Use #[{}(...)]", attr_path),
+            )),
+            syn::Meta::List(meta_list) => {
+                let inner_attr = syn::Attribute {
+                    pound_token: Token![#](meta_list.span()),
+                    style: syn::AttrStyle::Outer,
+                    bracket_token: attr.bracket_token,
+                    meta: {
+                        let m: syn::Meta = syn::parse2(meta_list.tokens.clone())?;
+                        //
+                        m
+                    },
+                };
+
+                Ok(Some(inner_attr))
+            }
+            syn::Meta::NameValue(meta_name_value) => Err(syn::Error::new(
+                meta_name_value.span(),
+                format!("Incorrect syntax, use #[{}(...)] instead", attr_path),
+            )),
+        }
+    }
+
+    fn define_attr(attr: &syn::Attribute) -> Result<Option<syn::Attribute>, syn::Error> {
+        if attr.path().is_ident("derive") {
+            Ok(Some(attr.clone()))
+        } else if attr.path().is_ident(DEFINITION_ATTR_PATH) {
+            Self::strip_attr_path_and_transform(attr, DEFINITION_ATTR_PATH)
+        } else if !(attr.path().is_ident("doc") || attr.path().is_ident(INSTANTIATION_ATTR_PATH)) {
+            Ok(Some(attr.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Returns Some if the attribute should be forwarded to the instantiation.
+    ///
+    /// Transforms the contents of the attribute, if applicable.
+    fn instance_attr(attr: &syn::Attribute) -> Result<Option<syn::Attribute>, syn::Error> {
+        if attr.path().is_ident("doc") {
+            Ok(Some(attr.clone()))
+        } else if attr.path().is_ident(INSTANTIATION_ATTR_PATH) {
+            Self::strip_attr_path_and_transform(attr, INSTANTIATION_ATTR_PATH)
+        } else if !(attr.path().is_ident("derive") || attr.path().is_ident(DEFINITION_ATTR_PATH)) {
+            Ok(Some(attr.clone()))
+        } else {
+            Ok(None)
+        }
+    }
+
+    /// Returns all attributes that should be forwarded to struct definitions.
+    ///
+    /// Transforms the contents of the attribute, if applicable.
+    pub fn definition_attrs(&self) -> Result<Vec<syn::Attribute>, syn::Error> {
         self.attrs
             .iter()
-            .filter(|a| match a.meta.require_name_value() {
-                Ok(nv) => nv.path.is_ident("doc"),
-                Err(_) => false,
+            .filter_map(|a| match Self::define_attr(a) {
+                Ok(Some(attr)) => Some(Ok(attr)),
+                Ok(None) => None,
+                Err(e) => Some(Err(e)),
             })
-            .collect()
+            .collect::<Result<Vec<_>, _>>()
+    }
+
+    /// Returns all attributes that should be forwarded to instantiation
+    pub fn instantiation_attrs(&self) -> Result<Vec<syn::Attribute>, syn::Error> {
+        self.attrs
+            .iter()
+            .filter_map(|a| match Self::instance_attr(a) {
+                Ok(Some(attr)) => Some(Ok(attr)),
+                Ok(None) => None,
+                Err(e) => Some(Err(e)),
+            })
+            .collect::<Result<Vec<_>, _>>()
     }
 }
 
@@ -520,4 +599,120 @@ mod tests {
     test_parse!(UsePath: test_parse_use_path_unused {
         "some_file_path.toml"
     });
+
+    /// Outer attributes only
+    ///
+    /// Used for macro doctest below
+    struct Attr(syn::Attribute);
+
+    impl Parse for Attr {
+        fn parse(input: syn::parse::ParseStream) -> syn::Result<Self> {
+            syn::Attribute::parse_outer(input).map(|res| Attr(res.into_iter().next().unwrap()))
+        }
+    }
+
+    /// Test attribute forwarding and transformation
+    #[test]
+    fn test_forward_attributes() {
+        macro_rules! test_forward {
+            ($($fn_path:ident)::+ (#[$attr: meta]) = $result: pat, $err: literal) => {
+                test_forward! {
+                    $($fn_path)::+ (#[$attr] => #[$attr]) = $result, $err
+                }
+            };
+
+            ($($fn_path:ident)::+ (#[$attr: meta] => #[$out_attr: meta]) = $result: pat, $err: literal) => {
+                let tokenstream = quote! {#[$attr]};
+                let attr: Result<Attr, _> = syn::parse2(tokenstream);
+
+                let res = attr.map(|a| {
+                    $($fn_path)::+(&a.0).expect("processing should not fail")
+                });
+
+                assert!(matches!(res, $result), $err);
+
+                if let Ok(Some(inner_attr)) = res {
+                    let expected_out_attr: Attr = syn::parse2(quote! {#[ $out_attr ]}).expect("failed to parse out attribute");
+                    assert_eq!(
+                        inner_attr.to_token_stream().to_string(),
+                        expected_out_attr.0.to_token_stream().to_string()
+                    );
+                }
+
+            };
+        }
+
+        // defines
+        test_forward! {MacroInput::define_attr(#[derive(Clone, Debug)]) = Ok(Some(_)), "derives are forwarded"}
+        test_forward! {MacroInput::define_attr(#[doc = "Docstring"]) = Ok(None), "doc attrs not forwarded"}
+        test_forward! {
+            MacroInput::define_attr(
+                #[define(some_definition_attr)] => #[some_definition_attr]
+            ) = Ok(Some(_)), "defines are forwarded"
+        }
+        test_forward! {
+            MacroInput::define_attr(
+                #[define(allow(unused))] => #[allow(unused)]
+            ) = Ok(Some(_)), "defines are forwarded"
+        }
+        test_forward! {MacroInput::define_attr(#[instance(some_instance_attr)]) = Ok(None), "instance not forwarded"}
+        test_forward! {MacroInput::define_attr(#[rustfmt::skip]) = Ok(Some(_)), "non matching attr paths are all forwarded"};
+
+        // instances
+        test_forward! {MacroInput::instance_attr(#[derive(Clone, Debug)]) = Ok(None), "derives are not forwarded"}
+        test_forward! {MacroInput::instance_attr(#[doc = "Docstring"]) = Ok(Some(_)), "doc attrs are forwarded"}
+        test_forward! {
+            MacroInput::instance_attr(
+                #[instance(some_instance_attr)] => #[some_instance_attr]
+            ) = Ok(Some(_)), "instances are forwarded"
+        }
+        test_forward! {
+            MacroInput::instance_attr(
+                #[instance(allow(unused))] => #[allow(unused)]
+            ) = Ok(Some(_)), "instances are forwarded"
+        }
+        test_forward! {MacroInput::instance_attr(#[define(some_define_attr)]) = Ok(None), "defines are not forwarded"};
+        test_forward! {MacroInput::instance_attr(#[rustfmt::skip]) = Ok(Some(_)), "non matching attr paths are all forwarded"};
+    }
+
+    /// Test attribute detection and forwarding
+    #[test]
+    fn test_forward_attributes_debug() {
+        // let attr1 = quote! {#[derive(Clone, Debug)]};
+        // let attr2 = quote! {#[doc = "Docstring"]};
+        // let attr3 = quote! {#[define(some_definition_attr)]};
+        let attr4 = quote! {#[define(allow(unused))]};
+        // let attr5 = quote! {#[instance(some_instance_attr)]};
+        // let attr6 = quote! {#[rustfmt::skip]};
+
+        // let attr1: Attr = syn::parse2(attr1).expect("failed to parse attr1");
+        // let attr2: Attr = syn::parse2(attr2).expect("failed to parse attr2");
+        // let attr3: Attr = syn::parse2(attr3).expect("failed to parse attr3");
+        let attr4: Attr = syn::parse2(attr4).expect("failed to parse attr4");
+        // let attr5: Attr = syn::parse2(attr5).expect("failed to parse attr5");
+        // let attr6: Attr = syn::parse2(attr6).expect("failed to parse attr6");
+
+        // println!("attr1: {:#?}", attr1.0.to_token_stream().to_string());
+        // println!("attr2: {:#?}", attr2.0.to_token_stream().to_string());
+        // println!("attr3: {:#?}", attr3.0.to_token_stream().to_string());
+        // println!("attr4: {:#?}", attr4.0.to_token_stream().to_string());
+        // println!("attr5: {:#?}", attr5.0.to_token_stream().to_string());
+        // println!("attr6: {:#?}", attr6.0.to_token_stream().to_string());
+
+        fn show_input_output(attr: syn::Attribute) {
+            println!("{}", attr.to_token_stream());
+            let res = MacroInput::define_attr(&attr);
+            if let Ok(Some(inner)) = res {
+                println!("{}", inner.to_token_stream());
+            }
+        }
+
+        show_input_output(attr4.0);
+    }
+
+    #[test]
+    fn test_forward_testing() {
+
+        // MacroInput::define_attr;
+    }
 }

--- a/toml_const_tests/src/lib.rs
+++ b/toml_const_tests/src/lib.rs
@@ -16,6 +16,8 @@ toml_const::toml_const_ws! {pub static TOML_CONST_EXAMPLE_WS: "./example.toml"; 
 
 toml_const::toml_const! {
     #[derive(PartialEq)]
+    #[instance(allow(unused))]
+    #[define(allow(unused))]
     const NORMALIZE_TOML: "../normalize.toml";
 }
 


### PR DESCRIPTION
Support more attributes to forward to generated code

```rust
toml_const::toml_const! {
    #[derive(PartialEq)] // forwarded to struct defs
    #[define(cfg_attr(debug_assertions, derive(Eq))] // forwarded to all struct defs
    #[define(doc = "Struct def docstring")] // also forwarded to struct defs
    #[instance(allow(uncommon_codepoints))] // forwarded to instance
    #[cfg_attr(test, allow(unused))] // forwarded to both struct defs and instance
    const TOML_CONST: "Cargo.toml";
}
```